### PR TITLE
Fix typo on _validate_bool

### DIFF
--- a/django_api_decorator/decorators.py
+++ b/django_api_decorator/decorators.py
@@ -220,7 +220,7 @@ def _validate_bool(value: str, *, query_param_name: str) -> bool:
         return True
 
     if value in ("no", "off", "false", "0"):
-        return True
+        return False
 
     raise ValidationError(f"{query_param_name} must be a boolean")
 


### PR DESCRIPTION
Fixing typo on _validate_bool so we can have for example `oda.com/api/endpoint?parameter=false` passed as a False bool.