### PR TITLE
Fix validation of mandatory query params and tests to cover it

### DIFF
--- a/django_api_decorator/decorators.py
+++ b/django_api_decorator/decorators.py
@@ -287,7 +287,7 @@ def _get_query_param_parser(
         for query_param, arg_name in query_param_mapping.items()
     }
     required_params = {
-        query_param
+        arg_name
         for query_param, arg_name in query_param_mapping.items()
         if parameters[arg_name].default is inspect.Parameter.empty
     }

--- a/poetry.lock
+++ b/poetry.lock
@@ -504,6 +504,24 @@ docs = ["sphinx", "sphinx-rtd-theme"]
 testing = ["Django", "django-configurations (>=2.0)"]
 
 [[package]]
+name = "pytest-mock"
+version = "3.10.0"
+description = "Thin-wrapper around the mock package for easier use with pytest"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pytest-mock-3.10.0.tar.gz", hash = "sha256:fbbdb085ef7c252a326fd8cdcac0aa3b1333d8811f131bdcc701002e1be7ed4f"},
+    {file = "pytest_mock-3.10.0-py3-none-any.whl", hash = "sha256:f4c973eeae0282963eb293eb173ce91b091a79c1334455acfac9ddee8a1c784b"},
+]
+
+[package.dependencies]
+pytest = ">=5.0"
+
+[package.extras]
+dev = ["pre-commit", "pytest-asyncio", "tox"]
+
+[[package]]
 name = "sqlparse"
 version = "0.4.3"
 description = "A non-validating SQL parser."
@@ -578,4 +596,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "cbd8495719608e163dcf56c6e356aac6dfd021cef8b76c6725d299f38cadbaf6"
+content-hash = "40723d0555abde4dd375c9bcaa16ef43d1268fbcf21a16ddda2a7b2d5382bfa7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ pytest-django = "^4.5.2"
 flake8-black = "^0.3.6"
 mypy = "^0.981"
 django-stubs = {extras = ["compatible-mypy"], version = "^1.13.1"}
+pytest-mock = "^3.10.0"
 
 [tool.isort]
 profile = "black"

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -1,6 +1,8 @@
 import datetime
+from functools import wraps
 from unittest import mock
 
+import pytest
 from django.http import HttpRequest, JsonResponse
 from django.test.client import Client
 from django.test.utils import override_settings
@@ -80,127 +82,148 @@ def test_login_required(client: Client) -> None:
         assert response.status_code == 200
 
 
-@override_settings(ROOT_URLCONF=__name__)
-def test_url_path(client: Client) -> None:
+def _create_api_view(view_func, query_params):  # type:ignore
+    collector = mock.Mock()
+
+    @api(
+        method="GET",
+        login_required=False,
+        query_params=query_params,
+    )
+    @wraps(view_func)
+    def view(*args, **kwargs):  # type: ignore
+        collector(*args, **kwargs)
+        view_func(*args, **kwargs)
+        return JsonResponse({})
+
+    return collector, view
+
+
+class TestViews:
+    @staticmethod
+    def required(r: HttpRequest, query_param: int) -> JsonResponse:
+        ...
+
+    @staticmethod
+    def optional(r: HttpRequest, query_param: int = 1) -> JsonResponse:
+        ...
+
+    @staticmethod
+    def string(r: HttpRequest, query_param: str) -> JsonResponse:
+        ...
+
+    @staticmethod
+    def date(r: HttpRequest, query_param: datetime.date) -> JsonResponse:
+        ...
+
+    @staticmethod
+    def number(r: HttpRequest, query_param: int) -> JsonResponse:
+        ...
+
+    @staticmethod
+    def boolean(r: HttpRequest, query_param: bool) -> JsonResponse:
+        ...
+
+    @staticmethod
+    def path_string(r: HttpRequest, pp: str) -> JsonResponse:
+        ...
+
+    @staticmethod
+    def path_int(r: HttpRequest, pp: str) -> JsonResponse:
+        ...
+
+    @staticmethod
+    def path_many(r: HttpRequest, pp1: str, pp2: int) -> JsonResponse:
+        ...
+
+
+@pytest.mark.parametrize(
+    "view,have_url,want_status,want_values",
+    [
+        (TestViews.required, "/?query-param=1", 200, {"query_param": 1}),
+        (TestViews.required, "/?query_param=1", 400, None),
+        (TestViews.required, "/", 400, None),
+        (TestViews.optional, "/?query-param=2", 200, {"query_param": 2}),
+        (TestViews.optional, "/", 200, {}),
+        (TestViews.string, "/?query-param=abc", 200, {"query_param": "abc"}),
+        (
+            TestViews.date,
+            "/?query-param=2020-01-01",
+            200,
+            {"query_param": datetime.date(2020, 1, 1)},
+        ),
+        (TestViews.date, "/?query-param=2020", 400, None),
+        (TestViews.number, "/?query-param=100", 200, {"query_param": 100}),
+        (TestViews.number, "/?query-param=abc", 400, None),
+        (TestViews.boolean, "/?query-param=true", 200, {"query_param": True}),
+        (TestViews.boolean, "/?query-param=True", 200, {"query_param": True}),
+        (TestViews.boolean, "/?query-param=yes", 200, {"query_param": True}),
+        (TestViews.boolean, "/?query-param=on", 200, {"query_param": True}),
+        (TestViews.boolean, "/?query-param=1", 200, {"query_param": True}),
+        (TestViews.boolean, "/?query-param", 200, {"query_param": True}),
+        (TestViews.boolean, "/?query-param=false", 200, {"query_param": False}),
+        (TestViews.boolean, "/?query-param=off", 200, {"query_param": False}),
+        (TestViews.boolean, "/?query-param=0", 200, {"query_param": False}),
+    ],
+)
+def test_query_params(  # type: ignore
+    mocker, client, settings, view, have_url, want_status, want_values
+):
+
+    collector, api_view = _create_api_view(view, ["query_param"])  # type: ignore
+    urls = [
+        path("", api_view),
+    ]
+
+    settings.ROOT_URLCONF = __name__
+    mocker.patch(f"{__name__}.urlpatterns", urls)
+    got = client.get(have_url)
+    assert got.status_code == want_status
+    if want_values is None:
+        collector.assert_not_called()
+    else:
+        collector.assert_called_once_with(mocker.ANY, **want_values)
+
+
+@pytest.mark.parametrize(
+    "view,path_spec,have_url,want_status,want_values",
+    [
+        (TestViews.path_string, "<str:pp>", "/hello", 200, {"pp": "hello"}),
+        (TestViews.path_string, "<str:pp>", "/", 404, None),
+        (TestViews.path_int, "<int:pp>", "/1", 200, {"pp": 1}),
+        (TestViews.path_int, "<int:pp>", "/h", 404, None),
+        (
+            TestViews.path_many,
+            "<str:pp1>/<int:pp2>",
+            "/hello/33",
+            200,
+            {"pp1": "hello", "pp2": 33},
+        ),
+    ],
+)
+def test_path_params(  # type: ignore
+    mocker, client, settings, view, path_spec, have_url, want_status, want_values
+):
     """
     Tests URL paths with the decorator. The decorator doesn't touch the parameters
     currently, so we are essentially testing Django internals, but it is good to have
     this check in case we start altering params.
     """
 
-    @api(method="GET", login_required=False)
-    def view(request: HttpRequest, a: int, b: str) -> JsonResponse:
-        return JsonResponse({"a": a, "b": b})
-
+    collector, api_view = _create_api_view(view, None)  # type: ignore
     urls = [
-        path("<int:a>/<str:b>", view),
+        path(path_spec, api_view),
     ]
+    settings.ROOT_URLCONF = __name__
+    mocker.patch(f"{__name__}.urlpatterns", urls)
 
-    with mock.patch(f"{__name__}.urlpatterns", urls):
-        response = client.get("/33/test")
-        assert response.status_code == 200
-        assert response.json() == {
-            "a": 33,
-            "b": "test",
-        }
+    got = client.get(have_url)
 
-        response = client.get("/33a/test")
-        assert response.status_code == 404
-
-
-@override_settings(ROOT_URLCONF=__name__)
-def test_url_path_and_query(client: Client) -> None:
-    @api(
-        method="GET",
-        login_required=False,
-        query_params=[
-            "num",
-            "opt_num",
-            "date",
-            "opt_date",
-            "string",
-            "opt_string",
-            "boolean",
-            "opt_boolean",
-        ],
-    )
-    def view(
-        request: HttpRequest,
-        a: int,
-        b: str,
-        num: int,
-        date: datetime.date,
-        string: str,
-        boolean: bool,
-        opt_num: int | None = None,
-        opt_date: datetime.date | None = None,
-        opt_string: str | None = None,
-        opt_boolean: bool | None = None,
-    ) -> JsonResponse:
-        return JsonResponse({})
-
-    urls = [
-        path("<int:a>/<str:b>", view),
-    ]
-
-    with mock.patch(f"{__name__}.urlpatterns", urls):
-        assert client.get("/33/test").status_code == 400
-        assert (
-            client.get(
-                "/33/test?num=3&date=2020-01-01&string=abc&boolean=false"
-            ).status_code
-            == 200
-        )
-        # Include some optional values
-        assert (
-            client.get(
-                "/33/test?num=3&date=2020-01-01&string=abc&boolean=false&opt_num=1"
-                "&opt_date=2022-01-01"
-            ).status_code
-            == 200
-        )
-        # Include all optional values
-        assert (
-            client.get(
-                "/33/test?num=3&date=2020-01-01&string=abc&boolean=false&opt_num=1"
-                "&opt_date=2022-01-01"
-                "&opt_string=123&opt_boolean=1"
-            ).status_code
-            == 200
-        )
-        # Include only optional values but no required
-        assert (
-            client.get(
-                "/33/test?opt_num=1&opt_date=2022-01-01&opt_string=123&opt_boolean=1"
-            ).status_code
-            == 400
-        )
-        # Invalid path
-        assert (
-            client.get(
-                "/a33/test?num=3&date=2020-01-01&string=abc&boolean=false"
-            ).status_code
-            == 404
-        )
-        # Invalid number
-        assert (
-            client.get(
-                "/33/test?num=3x&date=2020-01-01&string=abc&boolean=false"
-            ).status_code
-            == 400
-        )
-        # Invalid date
-        assert (
-            client.get(
-                "/33/test?num=3&date=2020-31-31&string=abc&boolean=false"
-            ).status_code
-            == 400
-        )
-        # Invalid bool
-        assert (
-            client.get("/33/test?num=3&date=2020-01-01&string=&boolean=xyz").status_code
-            == 400
-        )
+    assert got.status_code == want_status
+    if want_values is None:
+        collector.assert_not_called()
+    else:
+        collector.assert_called_once_with(mocker.ANY, **want_values)
 
 
 @override_settings(ROOT_URLCONF=__name__)


### PR DESCRIPTION
Mandatory query parameters ended up crashing rather than returning 400 bad request.
In this change, tests are expanded to cover the case and the issue is fixed.