### PR TITLE
Attention drawing commit about PublicAPIError

### DIFF
--- a/django_api_decorator/types.py
+++ b/django_api_decorator/types.py
@@ -35,5 +35,5 @@ class PublicAPIError(Exception):
     ) -> None:
         super().__init__(*args, *kwargs)
 
-        self.message = errors if errors is not None else [message]
+        self.message = errors if errors is not None and not message else message
         self.status_code = status_code

--- a/django_api_decorator/types.py
+++ b/django_api_decorator/types.py
@@ -23,6 +23,11 @@ class PublicAPIError(Exception):
     """
     Exception for public facing errors.
     Raises an ApiException in the frontend.
+
+    Args:
+        status_code (int | None, optional): HTTP status code. Defaults to 500.
+        message (str | None, optional): Public facing error message. Defaults to "".
+        errors (dict[str, Any] | None, optional): Underlying error messages. Defaults to None.
     """
 
     def __init__(


### PR DESCRIPTION
I'm not sure how the PublicAPIError is supposed to be used. Based on the docstring `Exception for public-facing errors`.  I was expecting that the `message` should be public-facing and `errors` could be used for the underlying reason for the error. However now if you provide both message  and errors  the message is set to errors

The pattern for `errors` is maybe something I should know, but I don't understand how the `dict[str, Any]` should be used. Maybe we can add some explanations in the docstring?