### PR TITLE
Use Pydantic's JSON encoder for everything

### DIFF
--- a/django_api_decorator/decorators.py
+++ b/django_api_decorator/decorators.py
@@ -439,7 +439,12 @@ def _get_response_encoder(*, type_annotation: Annotation) -> ResponseEncoder:
 
 
 def _json_encoder(*, payload: Any, status: int) -> HttpResponse:
-    return JsonResponse(payload, status=status, safe=False)
+    return JsonResponse(
+        payload,
+        status=status,
+        json_dumps_params={"default": pydantic_encoder},
+        safe=False,
+    )
 
 
 def _pydantic_encoder(payload: Any, status: int) -> HttpResponse:


### PR DESCRIPTION
This allows us to put pydantic models inside e.g. a TypedDict and have it serialize to JSON just fine. We could probably simplify the logic a lot by just using this on everything, but I think I'll leave major changes for the Pydantic v2 update.