### PR TITLE
Support serializing with the `by_alias` arg set

### DIFF
--- a/django_api_decorator/decorators.py
+++ b/django_api_decorator/decorators.py
@@ -31,6 +31,7 @@ def api(
     response_status: int = 200,
     atomic: bool | None = None,
     auth_check: Callable[[HttpRequest], bool] | None = None,
+    serialize_by_alias: bool = False
 ) -> Callable[[Callable[P, T]], Callable[P, HttpResponse]]:
     """
     Defines an API view. This handles validation of query parameters, parsing of
@@ -182,7 +183,7 @@ def api(
                 )
 
             # Encode the response from the view to json and create a response object.
-            payload = response_adapter.dump_json(response)
+            payload = response_adapter.dump_json(response, by_alias=serialize_by_alias)
             return HttpResponse(
                 payload, status=response_status, content_type="application/json"
             )

--- a/django_api_decorator/decorators.py
+++ b/django_api_decorator/decorators.py
@@ -31,7 +31,7 @@ def api(
     response_status: int = 200,
     atomic: bool | None = None,
     auth_check: Callable[[HttpRequest], bool] | None = None,
-    serialize_by_alias: bool = False
+    serialize_by_alias: bool = False,
 ) -> Callable[[Callable[P, T]], Callable[P, HttpResponse]]:
     """
     Defines an API view. This handles validation of query parameters, parsing of

--- a/django_api_decorator/decorators.py
+++ b/django_api_decorator/decorators.py
@@ -50,6 +50,10 @@ def api(
         HTTP status code to use if the view _does not_ return an
         Response object, but rather just the data we should return.
 
+    * serialize_by_alias:
+        Is passed as the by_alias argument to TypeAdapter.dump_json(), making
+        the model use the aliases defined in model_config when serializing.
+
     The request body parsing is done by inspecting the view parameter types. If
     the view has a body parameter, we will try to decode the payload to that
     type. Currently Django Rest Framework serializers and pydantic models are are

--- a/tests/test_response_encoding.py
+++ b/tests/test_response_encoding.py
@@ -92,7 +92,7 @@ urlpatterns = [
         ("/int", b"1"),
         ("/bool", b"false"),
         ("/pydantic-model", b'{"an_integer":1}'),
-        ("/pydantic-camel-case-model", b'{"anInteger":1}')
+        ("/pydantic-camel-case-model", b'{"anInteger":1}'),
     ],
 )
 @pytest.mark.urls(__name__)
@@ -146,9 +146,9 @@ def test_schema() -> None:
                                         "$ref": "#/components/schemas/MyCamelCasePydanticModel"
                                     }
                                 }
-                            }
+                            },
                         }
-                    }
+                    },
                 }
             },
             "/pydantic-model": {
@@ -236,19 +236,25 @@ def test_schema() -> None:
         "components": {
             "schemas": {
                 "MyCamelCasePydanticModel": {
-                    "properties": {"anInteger": {"title": "Aninteger", "type": "integer"}},
+                    "properties": {
+                        "anInteger": {"title": "Aninteger", "type": "integer"}
+                    },
                     "required": ["anInteger"],
                     "title": "MyCamelCasePydanticModel",
-                    "type": "object"
+                    "type": "object",
                 },
                 "MyPydanticModel": {
-                    "properties": {"an_integer": {"title": "An Integer", "type": "integer"}},
+                    "properties": {
+                        "an_integer": {"title": "An Integer", "type": "integer"}
+                    },
                     "required": ["an_integer"],
                     "title": "MyPydanticModel",
                     "type": "object",
                 },
                 "MyTypedDict": {
-                    "properties": {"an_integer": {"title": "An Integer", "type": "integer"}},
+                    "properties": {
+                        "an_integer": {"title": "An Integer", "type": "integer"}
+                    },
                     "required": ["an_integer"],
                     "title": "MyTypedDict",
                     "type": "object",

--- a/tests/test_response_encoding.py
+++ b/tests/test_response_encoding.py
@@ -104,7 +104,6 @@ def test_response_encoding(url: str, expected_response: bytes, client: Client) -
 
 def test_schema() -> None:
     spec = generate_api_spec(urlpatterns)
-    print(spec)
     assert spec == {
         "openapi": "3.1.0",
         "info": {"title": "API overview", "version": "0.0.1"},

--- a/tests/test_response_encoding.py
+++ b/tests/test_response_encoding.py
@@ -143,7 +143,7 @@ def test_schema() -> None:
                             "content": {
                                 "application/json": {
                                     "schema": {
-                                        "$ref": "#/components/schemas/MyCamelCasePydanticModel"
+                                        "$ref": "#/components/schemas/MyCamelCasePydanticModel"  # noqa: E501
                                     }
                                 }
                             },


### PR DESCRIPTION
Pydantic will, by default, serialize models with snake case. This change enables us to define custom aliases for the fields in the Pydantic model, and have the `@api` decorator serialize the model using those aliases.

This behavior was possible with the previous version of Pydantic, but was removed as part of the upgrade. Probably because Pydantic does things differently internally.

The usage we want is this:

1. Define a custom base class, that defines field aliases.
```
class CamelModel(pydantic.BaseModel):
    model_config = pydantic.ConfigDict(
        alias_generator=camel_case,
        populate_by_name=True,
    )
```

`camel_case` here is a function that converts field names from snake case to camel case.

2. Use this as the base for the Pydantic classes you want to serialize with camel case:

```
class Person(CamelModel):
   first_name: str
   last_name: str
```

3. Create `@api` view that returns an instance of this class, and makes it serialize with the alias. (Or create a local decorator that wraps `@api` and hardcodes this argument):

```
@api(method="GET", serialize_by_alias=True)
def person((request: HttpRequest) -> Person:

    return Person(first_name="Monty", last_name="Python")
```

The result would be a payload that looks something like this:
```
{
    "firstName": "Monty",
    "lastName": "Python"
}
```

An alternative approach could be to move away from the `TypeAdapter` approach, and instead just call `response.dump_model_json()`. Then the custom base class could define an override to it that and do whatever it wants with it (using `by_alias`, for example, but potentially also other things).