### PR TITLE
proposal on how to store more info in the openapi.json

### DIFF
--- a/django_api_decorator/openapi.py
+++ b/django_api_decorator/openapi.py
@@ -25,8 +25,8 @@ def get_resolved_url_patterns(
     and evaluates the full URLs of all django views that have a simple path (e.g. no
     regex). Returns a list of tuples with each RoutePattern and its full URL.
     """
-    
-    def combine_path(existing:str, append: str | None) -> str:
+
+    def combine_path(existing: str, append: str | None) -> str:
         if not append:
             return existing
         elif existing == "":
@@ -34,10 +34,10 @@ def get_resolved_url_patterns(
         else:
             return existing + ":" + append
 
-    unresolved_patterns: list[tuple[URLResolver | URLPattern, str]] = [
+    unresolved_patterns: list[tuple[URLResolver | URLPattern, str, str]] = [
         (url_pattern, "/", "") for url_pattern in base_patterns
     ]
-    resolved_urls: list[tuple[URLPattern, str]] = []
+    resolved_urls: list[tuple[URLPattern, str, str]] = []
 
     while len(unresolved_patterns):
         url_pattern, url_prefix, reverse_path = unresolved_patterns.pop()
@@ -52,10 +52,13 @@ def get_resolved_url_patterns(
         # If we are dealing with a URL Resolver we should dig further down.
         if isinstance(url_pattern, URLResolver):
             unresolved_patterns += [
-                (child_pattern, url, combine_path(reverse_path, url_pattern.namespace)) for child_pattern in url_pattern.url_patterns
+                (child_pattern, url, combine_path(reverse_path, url_pattern.namespace))
+                for child_pattern in url_pattern.url_patterns
             ]
         else:
-            resolved_urls.append((url_pattern, url, combine_path(reverse_path, url_pattern.name)))
+            resolved_urls.append(
+                (url_pattern, url, combine_path(reverse_path, url_pattern.name))
+            )
 
     return resolved_urls
 
@@ -97,7 +100,11 @@ def django_path_to_openapi_url_and_parameters(
 
 
 def paths_and_types_for_view(
-    *, view_name: str, callback: Callable[..., HttpResponse], resolved_url: str, reverse_path: str,
+    *,
+    view_name: str,
+    callback: Callable[..., HttpResponse],
+    resolved_url: str,
+    reverse_path: str,
 ) -> tuple[dict[str, Any], dict[str, Any]]:
     api_meta: ApiMeta | None = getattr(callback, "_api_meta", None)
 

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -4,7 +4,7 @@ from enum import Enum
 from django.http import HttpRequest
 from django.test.client import Client
 from django.test.utils import override_settings
-from django.urls import path, URLResolver, URLPattern
+from django.urls import URLPattern, URLResolver, path
 from django.urls.resolvers import RoutePattern
 from pydantic import BaseModel
 

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -287,7 +287,7 @@ def test_return_type_union(client: Client) -> None:
     }
 
 
-def test_get_resolved_url_patterns():
+def test_get_resolved_url_patterns() -> None:
     child_pattern = URLPattern(
         RoutePattern("child_pattern/nested/deep/"), lambda x: x, name="child_view"
     )

--- a/tests/test_response_encoding.py
+++ b/tests/test_response_encoding.py
@@ -113,6 +113,7 @@ def test_schema() -> None:
                     "operationId": "view_union",
                     "description": "",
                     "tags": ["test_response_encoding"],
+                    "x-reverse-path": "",
                     "parameters": [],
                     "responses": {
                         200: {
@@ -136,6 +137,7 @@ def test_schema() -> None:
                     "operationId": "view_camel_case_pydantic_model",
                     "description": "",
                     "tags": ["test_response_encoding"],
+                    "x-reverse-path": "",
                     "parameters": [],
                     "responses": {
                         200: {
@@ -156,6 +158,7 @@ def test_schema() -> None:
                     "operationId": "view_pydantic_model",
                     "description": "",
                     "tags": ["test_response_encoding"],
+                    "x-reverse-path": "",
                     "parameters": [],
                     "responses": {
                         200: {
@@ -176,6 +179,7 @@ def test_schema() -> None:
                     "operationId": "view_bool",
                     "description": "",
                     "tags": ["test_response_encoding"],
+                    "x-reverse-path": "",
                     "parameters": [],
                     "responses": {
                         200: {
@@ -192,6 +196,7 @@ def test_schema() -> None:
                     "operationId": "view_int",
                     "description": "",
                     "tags": ["test_response_encoding"],
+                    "x-reverse-path": "",
                     "parameters": [],
                     "responses": {
                         200: {
@@ -208,6 +213,7 @@ def test_schema() -> None:
                     "operationId": "view_typed_dict",
                     "description": "",
                     "tags": ["test_response_encoding"],
+                    "x-reverse-path": "",
                     "parameters": [],
                     "responses": {
                         200: {
@@ -228,6 +234,7 @@ def test_schema() -> None:
                     "operationId": "view_json_response",
                     "description": "",
                     "tags": ["test_response_encoding"],
+                    "x-reverse-path": "",
                     "parameters": [],
                     "responses": {200: {"description": ""}},
                 }


### PR DESCRIPTION
I just typed this change out here in github, not spending too much time on it if it's not popular ;) 

Idea is to generate openapi.json on the form of
```
        "/api/v1/picking_oee/{some_id}/tasks/some-action/": {
            "put": {
                "operationId": "some-action",
                "description": "...",
                "tags": [
                    "picking"
                ],
                "x-reverse-path": "api:picking_oee:some-action", <----==== the new thingy
```

so that I in some other generator-code later can see that this is actually not just the picking module (which the tag is), but the specific sub-module in the reverse-path, with arbitrary many levels of something:something:something