### PR TITLE
Add possibility to ignore apps + namespace in the generated schema

### DIFF
--- a/django_api_decorator/schema_file.py
+++ b/django_api_decorator/schema_file.py
@@ -28,7 +28,10 @@ def get_api_spec() -> dict[str, Any]:
         if not isinstance(resolver_or_pattern, URLResolver):
             continue
 
-        app_name, namespace = resolver_or_pattern.app_name, resolver_or_pattern.namespace
+        app_name, namespace = (
+            resolver_or_pattern.app_name,
+            resolver_or_pattern.namespace,
+        )
         if (app_name, namespace) in ignored_resolvers:
             resolvers_to_ignore.append(resolver_or_pattern)
 

--- a/django_api_decorator/schema_file.py
+++ b/django_api_decorator/schema_file.py
@@ -45,8 +45,8 @@ def get_api_spec() -> dict[str, Any]:
 def get_path() -> Path:
     if not hasattr(settings, "API_DECORATOR_SCHEMA_PATH"):
         raise ValueError(
-            "API_DECORATOR_SCHEMA_PATH must be set in settings in order to save the api spec "
-            "to a file."
+            "API_DECORATOR_SCHEMA_PATH must be set in settings in order to save the "
+            "api spec to a file."
         )
 
     path = Path(settings.API_DECORATOR_SCHEMA_PATH)  # type: ignore[misc]

--- a/django_api_decorator/schema_file.py
+++ b/django_api_decorator/schema_file.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Any
 
 from django.conf import settings
+from django.urls.resolvers import URLResolver
 
 from .openapi import generate_api_spec
 
@@ -19,13 +20,29 @@ def get_api_spec() -> dict[str, Any]:
 
     urlpatterns = import_module(settings.ROOT_URLCONF).urlpatterns
 
+    ignored_resolvers = getattr(settings, "API_DECORATOR_SCHEMA_IGNORED_RESOLVERS", [])
+    resolvers_to_ignore = []
+
+    # iterate through urlpatterns to find resolvers to remove.
+    for resolver_or_pattern in urlpatterns:
+        if not isinstance(resolver_or_pattern, URLResolver):
+            continue
+
+        app_name, namespace = resolver_or_pattern.app_name, resolver_or_pattern.namespace
+        if (app_name, namespace) in ignored_resolvers:
+            resolvers_to_ignore.append(resolver_or_pattern)
+
+    # Remove ignored resovlers from the urlpatterns sequence.
+    for resolver in resolvers_to_ignore:
+        urlpatterns.remove(resolver)
+
     return generate_api_spec(urlpatterns=urlpatterns)
 
 
 def get_path() -> Path:
     if not hasattr(settings, "API_DECORATOR_SCHEMA_PATH"):
         raise ValueError(
-            "ROOT_URLCONF must be set in settings in order to save the api spec "
+            "API_DECORATOR_SCHEMA_PATH must be set in settings in order to save the api spec "
             "to a file."
         )
 


### PR DESCRIPTION
We have a problem in one of our projects where other projects using the api decorator bleeds into our API schema. We still want these endpoints to be exposed and work, but we dont need any of our code to interact with it directly, hence I'm adding the possibility of ignoring resolvers from app_name + namespace combo.