### PR TITLE
Specify query parameters with type annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ from simple types to dataclasses and typed dicts.
 Here's a simple example:
 
 ```python
+from django_api_decorator.decorators import api
+
 @api(method="GET")
 def list_some_numbers(request: HttpRequest) -> list[int]:
     return [1, 2, 3, 4]
@@ -40,8 +42,10 @@ You can also specify query parameters, that will be decoded according to the
 specified type annotations:
 
 ```python
-@api(method="GET", query_params=["count"])
-def list_some_numbers(request: HttpRequest, count: int) -> list[int]:
+from django_api_decorator.types import Query
+
+@api(method="GET")
+def list_some_numbers(request: HttpRequest, count: Query[int]) -> list[int]:
     return [random.randint(0, 10) for _ in range(count)]
 ```
 

--- a/django_api_decorator/decorators.py
+++ b/django_api_decorator/decorators.py
@@ -3,7 +3,7 @@ import inspect
 import logging
 import typing
 from collections.abc import Callable, Mapping
-from typing import Annotated, Any, TypedDict
+from typing import Annotated, Any, TypedDict, get_origin, get_args
 
 import pydantic
 from django.conf import settings
@@ -15,7 +15,7 @@ from pydantic.fields import FieldInfo
 from pydantic.functional_validators import BeforeValidator
 from pydantic_core import PydanticUndefined
 
-from .types import ApiMeta, FieldError, PublicAPIError
+from .types import ApiMeta, FieldError, PublicAPIError, _QueryType
 from .utils import get_list_fields, parse_form_encoded_body
 
 P = typing.ParamSpec("P")
@@ -240,9 +240,21 @@ def _get_query_params_model(
     if any(arg_name not in parameters for arg_name in query_params):
         raise TypeError("All parameters specified in query_params must exist")
 
+    field_names = query_params.copy()
+
+    # Find parameters annotated using `Query[<type>]` types instead of being
+    # specified in the query_params argument to the decorator
+    field_names += [
+        arg_name
+        for arg_name, parameter in parameters.items()
+        if get_origin(parameter.annotation) is Annotated
+        and _QueryType in get_args(parameter.annotation)
+        and arg_name not in query_params
+    ]
+
     fields: dict[str, tuple[Any, FieldInfo]] = {}
 
-    for arg_name in query_params:
+    for arg_name in field_names:
         annotation = parameters[arg_name].annotation
         annotation = TYPE_MAPPING.get(annotation, annotation)
         field = pydantic.fields.Field(

--- a/django_api_decorator/types.py
+++ b/django_api_decorator/types.py
@@ -1,7 +1,9 @@
 from dataclasses import dataclass
-from typing import Any, TypedDict
+from typing import Any, TypedDict, TypeVar, Annotated
 
 from pydantic import BaseModel, TypeAdapter
+
+T = TypeVar("T")
 
 
 class FieldError(TypedDict):
@@ -42,3 +44,11 @@ class PublicAPIError(Exception):
 
         self.message = errors if errors is not None else [message]
         self.status_code = status_code
+
+
+class _QueryType:
+    """
+    An input type provided as a query parameter
+    """
+
+Query = Annotated[T, _QueryType]


### PR DESCRIPTION
This adds an option to specify query parameters using type annotations rather than the query_params parameter to the decorator. I find this much cleaner and it avoids any problems with typos etc.

Inspired by Andrew Godwin's [django-hatchway][1].

[1]: https://github.com/andrewgodwin/django-hatchway/tree/main/hatchway