### PR TITLE
Make it possible to tag apis

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,3 +92,38 @@ documentation](https://docs.pydantic.dev/latest/usage/json_schema/).
 
 The specification is generated using the `generate_api_schemas` management
 command.
+
+### Control Operations Included in the Schema
+
+Controlling which operations are included in the generated schema can be useful.
+Your application might depend on libraries that also use the `django-api-decorator`
+package to build APIs, and you may prefer not to include those in your schema.
+
+This is achieved by defining a set of tags on each view method.
+
+```python
+@api(method="GET", tags=["django-api-decorator"])
+def view(request: HttpRequest) -> None:
+    ...
+```
+
+Views without the tags property set will always be included in the schema.
+
+You can either exclude tags you don't want in your schema or select tags you
+want to include. However, you cannot both include and exclude tags simultaneously.
+
+#### Including Tags in the Schema
+
+Specify the tags to include in your schema in the Django settings file:
+
+```python
+API_DECORATOR_SCHEMA_INCLUDE_TAGS = ["app", ...]
+```
+
+#### Excluding Tags from the Schema
+
+Specify the tags to exclude from your schema in the Django settings file:
+
+```python
+API_DECORATOR_SCHEMA_EXCLUDE_TAGS = ["library", ...]
+```

--- a/django_api_decorator/decorators.py
+++ b/django_api_decorator/decorators.py
@@ -37,6 +37,7 @@ def api(
     auth_check: Callable[[HttpRequest], bool] | None = None,
     serialize_by_alias: bool = False,
     validation_error_handler: ExceptionHandler | None = None,
+    tags: list[str] | None = None,
 ) -> Callable[[Callable[P, T]], Callable[P, HttpResponse]]:
     """
     Defines an API view. This handles validation of query parameters, parsing of
@@ -212,6 +213,7 @@ def api(
             body_adapter=body_adapter,
             query_params_model=query_params_model,
             response_adapter=response_adapter,
+            tags=tags,
         )
         return inner
 

--- a/django_api_decorator/types.py
+++ b/django_api_decorator/types.py
@@ -22,6 +22,7 @@ class ApiMeta:
     query_params_model: BaseModel
     body_adapter: TypeAdapter[Any] | None
     response_adapter: TypeAdapter[Any] | None
+    tags: list[str] | None
 
 
 class PublicAPIError(Exception):


### PR DESCRIPTION
Operations can now be included/excluded from the openapi schema based on tags.