### PR TITLE
fix: Warn if API_DECORATOR_SCHEMA_IGNORED_RESOLVERS is used

### DIFF
--- a/django_api_decorator/schema_file.py
+++ b/django_api_decorator/schema_file.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import warnings
 from importlib import import_module
 from pathlib import Path
 from typing import Any
@@ -21,6 +22,15 @@ def get_api_spec() -> dict[str, Any]:
     urlpatterns = import_module(settings.ROOT_URLCONF).urlpatterns
 
     ignored_resolvers = getattr(settings, "API_DECORATOR_SCHEMA_IGNORED_RESOLVERS", [])
+    if ignored_resolvers:
+        warnings.warn(
+            "API_DECORATOR_SCHEMA_IGNORED_RESOLVERS is deprecated, use "
+            "API_DECORATOR_SCHEMA_EXCLUDE_TAGS or API_DECORATOR_SCHEMA_INCLUDE_TAGS "
+            "instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
     resolvers_to_ignore = []
 
     # iterate through urlpatterns to find resolvers to remove.

--- a/tests/test_schema_file.py
+++ b/tests/test_schema_file.py
@@ -1,0 +1,29 @@
+import pytest
+from django.http import HttpRequest
+from django.test.client import Client
+from django.test.utils import override_settings
+from django.urls import path
+
+from django_api_decorator.decorators import api
+from django_api_decorator.schema_file import get_api_spec
+
+
+@api(method="GET")
+def view(
+    request: HttpRequest,
+) -> None:
+    return None
+
+
+urlpatterns = [
+    path("view", view, name="view_name"),
+]
+
+
+@override_settings(
+    ROOT_URLCONF=__name__,
+    API_DECORATOR_SCHEMA_IGNORED_RESOLVERS=[("test", "test")],
+)
+def test_get_api_spec_deprecated_filter(client: Client) -> None:
+    with pytest.deprecated_call():
+        get_api_spec()


### PR DESCRIPTION
API_DECORATOR_SCHEMA_EXCLUDE_TAGS or API_DECORATOR_SCHEMA_INCLUDE_TAGS should be used instead.