### PR TITLE
feat: Make sure tags flow from OpenApiOperation to path tags

### DIFF
--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -334,7 +334,7 @@ def test_openapi_spec_include_tagged_operations(client: Client) -> None:
                 "get": {
                     "operationId": "view_name",
                     "description": "",
-                    "tags": ["test_openapi"],
+                    "tags": ["django-api-decorator", "test_openapi"],
                     "x-reverse-path": "view_name",
                     "parameters": [],
                     "responses": {
@@ -443,7 +443,7 @@ def test_openapi_spec_exclude_operation(client: Client) -> None:
                 "get": {
                     "operationId": "b",
                     "description": "",
-                    "tags": ["test_openapi"],
+                    "tags": ["b", "test_openapi"],
                     "x-reverse-path": "b",
                     "parameters": [],
                     "responses": {
@@ -491,7 +491,7 @@ def test_openapi_spec_include_operation(client: Client) -> None:
                 "get": {
                     "operationId": "b",
                     "description": "",
-                    "tags": ["test_openapi"],
+                    "tags": ["b", "test_openapi"],
                     "x-reverse-path": "b",
                     "parameters": [],
                     "responses": {


### PR DESCRIPTION
### Include tags in schema
I was working with `API_DECORATOR_SCHEMA_EXCLUDE_TAGS` and `API_DECORATOR_SCHEMA_INCLUDE_TAGS` and noticed that while the logic correctly includes and excludes paths, it does not propagate the tags into the schema as expected.

If a tag is used to `exclude` a path, the entire object is removed from the schema, which makes sense 👍🏻. However, when a tag is used to `include` a path, I would expect that path to appear in the schema with the corresponding tags.

This change ensures that `tags: list[str] | None` flows into `paths_and_types_for_view` and is then added in a sorted, stable manner to the `paths` object in the schema.

As a user of the decorator, I would expect an API I tagged to reflect those tags in the schema. I also like that `app_name` is automatically added as a tag, so I included it in the ordered set of tags.

Beyond that, I think the tests speak for themselves.