### PR TITLE
feat: use serialization mode when dumping response schemas

### DIFF
--- a/django_api_decorator/openapi.py
+++ b/django_api_decorator/openapi.py
@@ -131,7 +131,9 @@ def paths_and_types_for_view(
 
     if api_meta.response_adapter:
         response_schema = api_meta.response_adapter.json_schema(
-            ref_template=schema_ref, by_alias=generate_schema_by_alias
+            ref_template=schema_ref,
+            by_alias=generate_schema_by_alias,
+            mode="serialization",
         )
         if defs := response_schema.pop("$defs", None):
             components.update(defs)
@@ -143,7 +145,9 @@ def paths_and_types_for_view(
     request_body = {}
     if api_meta.body_adapter:
         body_schema = api_meta.body_adapter.json_schema(
-            ref_template=schema_ref, by_alias=generate_schema_by_alias
+            ref_template=schema_ref,
+            by_alias=generate_schema_by_alias,
+            mode="serialization",
         )
         if defs := body_schema.pop("$defs", None):
             components.update(defs)
@@ -161,7 +165,9 @@ def paths_and_types_for_view(
 
     for name, field in api_meta.query_params_model.model_fields.items():
         schema = pydantic.TypeAdapter(field.annotation).json_schema(
-            ref_template=schema_ref, by_alias=generate_schema_by_alias
+            ref_template=schema_ref,
+            by_alias=generate_schema_by_alias,
+            mode="serialization",
         )
         schema = to_ref_if_object(schema)
         if field.default != PydanticUndefined:

--- a/django_api_decorator/openapi.py
+++ b/django_api_decorator/openapi.py
@@ -147,7 +147,7 @@ def paths_and_types_for_view(
         body_schema = api_meta.body_adapter.json_schema(
             ref_template=schema_ref,
             by_alias=generate_schema_by_alias,
-            mode="serialization",
+            mode="validation",
         )
         if defs := body_schema.pop("$defs", None):
             components.update(defs)
@@ -167,7 +167,7 @@ def paths_and_types_for_view(
         schema = pydantic.TypeAdapter(field.annotation).json_schema(
             ref_template=schema_ref,
             by_alias=generate_schema_by_alias,
-            mode="serialization",
+            mode="validation",
         )
         schema = to_ref_if_object(schema)
         if field.default != PydanticUndefined:

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -650,7 +650,7 @@ def test_openapi_spec_computed_fields__response(client: Client) -> None:
         first_name: str
         last_name: str
 
-        @computed_field
+        @computed_field  # type: ignore[misc]
         @property
         def full_name(self) -> str:
             return f"{self.first_name} {self.last_name}"
@@ -679,7 +679,7 @@ def test_openapi_spec_computed_fields__body(client: Client) -> None:
         first_name: str
         last_name: str
 
-        @computed_field
+        @computed_field  # type: ignore[misc]
         @property
         def full_name(self) -> str:
             return f"{self.first_name} {self.last_name}"


### PR DESCRIPTION
Computed fields are part of the response being returned anyways, so it should be part of the schema. 

I decided to only target response schemas, and leave request/query params as validation. It might be up to each types generator if you have to add readOnly fields to the request payload if they're present, but they are not validated on request, and therefore not needed in the schema.