### PR TITLE
feat: add support for custom url converters

### DIFF
--- a/django_api_decorator/openapi.py
+++ b/django_api_decorator/openapi.py
@@ -9,10 +9,9 @@ import pydantic
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.http import HttpResponse
-from django.urls.converters import REGISTERED_CONVERTERS, get_converters
+from django.urls.converters import REGISTERED_CONVERTERS
 from django.urls.resolvers import RoutePattern, URLPattern, URLResolver
 from pydantic_core import PydanticUndefined
-from typing_extensions import Literal
 
 from .types import ApiMeta, OpenApiServer
 
@@ -87,7 +86,7 @@ def _get_converter_schema(converter: BaseConverter | None) -> dict[str, Any] | N
     type_hints = get_type_hints(converter.to_python, include_extras=True)
     return_type = type_hints.get("return")
 
-    if return_type is not None and return_type is not type(None):
+    if return_type is not None:
         # Use Pydantic to generate schema from the return type
         schema = pydantic.TypeAdapter(return_type).json_schema()
         return schema

--- a/django_api_decorator/openapi.py
+++ b/django_api_decorator/openapi.py
@@ -3,14 +3,16 @@ import logging
 import re
 import textwrap
 from collections.abc import Callable, Sequence
-from typing import Any, cast
+from typing import Any, Protocol, cast, get_type_hints
 
 import pydantic
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.http import HttpResponse
+from django.urls.converters import REGISTERED_CONVERTERS, get_converters
 from django.urls.resolvers import RoutePattern, URLPattern, URLResolver
 from pydantic_core import PydanticUndefined
+from typing_extensions import Literal
 
 from .types import ApiMeta, OpenApiServer
 
@@ -65,6 +67,40 @@ def get_resolved_url_patterns(
     return resolved_urls
 
 
+class BaseConverter(Protocol):
+    regex: str
+    to_python: Callable[[str], Any]
+
+
+def _get_converter_schema(converter: BaseConverter | None) -> dict[str, Any] | None:
+    """
+    Gets the OpenAPI schema for a converter by inspecting its to_python return type.
+    Falls back to regex parsing if type annotation is not available.
+    """
+    if converter is None:
+        return None
+
+    assert _is_url_converter(converter)
+
+    # Try to get type hints from the method
+    # get_type_hints works on both bound and unbound methods
+    type_hints = get_type_hints(converter.to_python, include_extras=True)
+    return_type = type_hints.get("return")
+
+    if return_type is not None and return_type is not type(None):
+        # Use Pydantic to generate schema from the return type
+        schema = pydantic.TypeAdapter(return_type).json_schema()
+        return schema
+    else:
+        logger.info("No return type found for converter %s. Is it typed?", converter)
+
+    return None
+
+
+def _is_url_converter(converter: Any) -> bool:
+    return hasattr(converter, "to_python")
+
+
 def django_path_to_openapi_url_and_parameters(
     path: str,
 ) -> tuple[str, list[dict[str, Any]]]:
@@ -72,24 +108,27 @@ def django_path_to_openapi_url_and_parameters(
     Returns an OpenAPI URL and the URL parameter specs, given a django url.
     """
 
-    # mapping django url types to openapi types
-    url_parameter_type_mapping = {
-        "int": "integer",
-        "str": "string",
-        "slug": "string",
-    }
-
+    converters = {"int": int, "str": str, "slug": str, **REGISTERED_CONVERTERS}
     parameters = []
 
     def replacer(match: re.Match[str]) -> str:
         parameter_type = match.group(1)
         parameter_name = match.group(2)
+
+        # Get the converter instance/class
+        converter_or_primitive = converters.get(parameter_type)
+
+        if _is_url_converter(converter_or_primitive):
+            schema = _get_converter_schema(converter_or_primitive)
+        else:
+            schema = pydantic.TypeAdapter(converter_or_primitive).json_schema()
+
         parameters.append(
             {
                 "name": parameter_name,
                 "in": "path",
                 "required": True,
-                "schema": {"type": url_parameter_type_mapping.get(parameter_type)},
+                "schema": schema,
             }
         )
         return "{" + parameter_name + "}"

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -1,14 +1,16 @@
 import datetime
 from enum import Enum
+from typing import Any
 
 import pytest
 from django.core.exceptions import ImproperlyConfigured
 from django.http import HttpRequest
 from django.test.client import Client
 from django.test.utils import override_settings
-from django.urls import URLPattern, URLResolver, path
+from django.urls import URLPattern, URLResolver, path, register_converter
 from django.urls.resolvers import RoutePattern
 from pydantic import BaseModel, computed_field
+from typing_extensions import Literal
 
 from django_api_decorator.decorators import api
 from django_api_decorator.openapi import generate_api_spec, get_resolved_url_patterns
@@ -697,3 +699,60 @@ def test_openapi_spec_computed_fields__body(client: Client) -> None:
         "full_name"
         not in generate_api_spec(urls)["components"]["schemas"]["A"]["properties"]
     )
+
+
+@pytest.mark.parametrize(
+    "type_, expected_parameter_spec",
+    [
+        ("int", {"type": "integer"}),
+        ("str", {"type": "string"}),
+        ("slug", {"type": "string"}),
+    ],
+)
+def test_openapi_spec_path__defaults(
+    client: Client, type_: str, expected_parameter_spec: dict[str, Any]
+) -> None:
+    class A(BaseModel):
+        name: str
+
+    @api(method="GET")
+    def view(request: HttpRequest) -> A:
+        return A(name="John")
+
+    urls = [path(f"view/<{type_}:id>", view, name="view")]
+    spec = generate_api_spec(urls)
+
+    parameter_spec = spec["paths"]["/view/{id}"]["get"]["parameters"][0]["schema"]
+    print(parameter_spec)
+    assert parameter_spec == expected_parameter_spec
+
+
+def test_openapi_spec_path__custom_converter(client: Client) -> None:
+    class A(BaseModel):
+        name: str
+
+    @api(method="GET")
+    def view(request: HttpRequest) -> A:
+        return A(name="John")
+
+    class CustomConverter:
+        regex = r"[0-9]+|custom-id"
+
+        def to_python(self, value: str) -> int | Literal["custom-id"]:
+            if value.isdigit():
+                return int(value)
+            return "custom-id"
+
+        def to_url(self, value: int | Literal["custom-id"]) -> str:
+            if value == "custom-id":
+                return "custom-id"
+            return str(value)
+
+    register_converter(CustomConverter, "custom")
+    urls = [
+        path("view/<custom:id>", view, name="view"),
+    ]
+    spec = generate_api_spec(urls)
+
+    parameter_spec = spec["paths"]["/view/{id}"]["get"]["parameters"][0]["schema"]
+    assert parameter_spec == {"anyOf": [{"type": "integer"}, {"const": "custom-id"}]}

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -719,7 +719,7 @@ def test_openapi_spec_path__defaults(
     def view(request: HttpRequest) -> A:
         return A(name="John")
 
-    urls = [path(f"view/<{type_}:id>", view, name="view")]
+    urls = [path(f"view/<{type_}:id>", view, name="view")]  # noqa
     spec = generate_api_spec(urls)
 
     parameter_spec = spec["paths"]["/view/{id}"]["get"]["parameters"][0]["schema"]


### PR DESCRIPTION
Add support for custom url converters/dispatchers (https://docs.djangoproject.com/en/5.2/topics/http/urls/#registering-custom-path-converters).